### PR TITLE
Remove italics from comments

### DIFF
--- a/RealGithub.tmTheme
+++ b/RealGithub.tmTheme
@@ -64,8 +64,6 @@
 			<dict>
 				<key>foreground</key>
 				<string>#969896</string>
-				<key>fontStyle</key>
-				<string>italic</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Thanks a lot for this theme, there are so many "GitHub" themes that do not look like GitHub!

As of this writing, GitHub does not use italics for comments.